### PR TITLE
Skip bundle templates

### DIFF
--- a/src/Rule/CaseSensitiveInclude.php
+++ b/src/Rule/CaseSensitiveInclude.php
@@ -88,6 +88,12 @@ final class CaseSensitiveInclude extends AbstractRule implements RuleInterface
 
     private function exists(string $include) : bool
     {
+        if (strpos($include, '@') === 0) {
+            // Skip Bundle Templates
+            // See: https://symfony.com/doc/current/templates.html#bundle-templates
+            return true;
+        }
+
         foreach ($this->paths as $i => $absoluteDir) {
             $absolutePath = $absoluteDir . DIRECTORY_SEPARATOR . $include;
             if (in_array($absolutePath, $this->getGlobPaths(), true)) {

--- a/tests/Rule/CaseSensitiveIncludeTest.php
+++ b/tests/Rule/CaseSensitiveIncludeTest.php
@@ -79,6 +79,36 @@ class CaseSensitiveIncludeTest extends TestCase
                 ),
                 1
             ],
+            'bundle_template:include' => [
+                $lexer->tokenize(
+                    new Source(
+                        '{% include "@AcmeFoo/user/profile.html.twig" %}',
+                        'my/path/file.html.twig',
+                        'my/path/file.html.twig'
+                    )
+                ),
+                0
+            ],
+            'bundle_template:extends' => [
+                $lexer->tokenize(
+                    new Source(
+                        '{% extends "@AcmeFoo/user/profile.html.twig" %}',
+                        'my/path/file.html.twig',
+                        'my/path/file.html.twig'
+                    )
+                ),
+                0
+            ],
+            'bundle_template:import' => [
+                $lexer->tokenize(
+                    new Source(
+                        '{% import "@AcmeFoo/user/profile.html.twig" as foo %}',
+                        'my/path/file.html.twig',
+                        'my/path/file.html.twig'
+                    )
+                ),
+                0
+            ],
         ];
     }
 


### PR DESCRIPTION
[Creating and Using Templates (Symfony Docs)](https://symfony.com/doc/current/templates.html#bundle-templates) にあるような Bundle Templates を include する場合、
単純なファイル存在チェックではエラーになってしまいます。

これを避けるためには、Twig の Loader から Bundle の名前空間を解決（See: https://twig.symfony.com/doc/3.x/api.html#built-in-loaders ）する必要があり、処理が少し複雑なため、ひとまずは Bundle templates の場合はSKIPするようにしました。
