### PR TITLE
Skip `import _self`

### DIFF
--- a/tests/Rule/CaseSensitiveIncludeTest.php
+++ b/tests/Rule/CaseSensitiveIncludeTest.php
@@ -109,6 +109,36 @@ class CaseSensitiveIncludeTest extends TestCase
                 ),
                 0
             ],
+            '_self:include' => [
+                $lexer->tokenize(
+                    new Source(
+                        '{% include _self %}',
+                        'my/path/file.html.twig',
+                        'my/path/file.html.twig'
+                    )
+                ),
+                1
+            ],
+            '_self:extends' => [
+                $lexer->tokenize(
+                    new Source(
+                        '{% extends _self %}',
+                        'my/path/file.html.twig',
+                        'my/path/file.html.twig'
+                    )
+                ),
+                1
+            ],
+            '_self:import' => [
+                $lexer->tokenize(
+                    new Source(
+                        '{% import _self as foo %}',
+                        'my/path/file.html.twig',
+                        'my/path/file.html.twig'
+                    )
+                ),
+                0
+            ],
         ];
     }
 


### PR DESCRIPTION
Twig2系かつ2.11未満では同一ファイルに定義したmacroを使う場合、

```twig
{% import _self as forms %}

<p>{{ forms.input('username') }}</p>
```

このように書く必要がある。
See: [macro - Documentation - Twig - The flexible, fast, and secure PHP template engine](https://twig.symfony.com/doc/2.x/tags/macro.html) の Tip 参照

しかしながら、これに対応していないため、下記のようなエラーがでてしまう。
```
Error: import "_self" is not valid path.
```

問題ない書き方なので `import _self` はSKIPするようにした。


